### PR TITLE
feat: Update Box "large" spacing and add spacing story

### DIFF
--- a/src/components/Box/__stories__/Box.stories.js
+++ b/src/components/Box/__stories__/Box.stories.js
@@ -1,5 +1,6 @@
 import Box from '../index'
 export { default as Default } from './BoxDefault.story'
+export { default as Spacing } from './BoxSpacing.story'
 
 export default {
   title: 'Box',

--- a/src/components/Box/__stories__/BoxSpacing.story.js
+++ b/src/components/Box/__stories__/BoxSpacing.story.js
@@ -1,0 +1,27 @@
+import spacingAliases from '../../../constants/spacingAliases'
+import Box, { getRemFromSpacing } from '../index'
+
+export default () => ({
+  components: { Box },
+  data: () => ({
+    spacingAliases,
+  }),
+  template: `
+    <div class="p-6">
+      <div v-for="(alias, index) in spacingAliases" :key="alias">
+        <Box
+          class="border"
+          :padding="alias"
+          :marginBottom="alias"
+          >
+          {{ alias }} - {{ getSpacingRemValue(alias) }}
+        </Box>
+      </div>
+    </div>
+  `,
+  methods: {
+    getSpacingRemValue(alias) {
+      return getRemFromSpacing(alias)
+    },
+  },
+})

--- a/src/components/Box/index.vue
+++ b/src/components/Box/index.vue
@@ -104,7 +104,7 @@ function getIsSpacingPropValid(propName) {
   }
 }
 
-function getRemFromSpacing(spacing) {
+export function getRemFromSpacing(spacing) {
   if (isNumber(spacing) || !isNaN(parseFloat(spacing))) {
     return `${(spacing * 4) / 16}rem`
   }


### PR DESCRIPTION
This PR increase the `large` spacing alias to be the more commonly used `2.5rem` value.

It also adds a story to demonstrage the various different values for the spacing as a nice reference point when interpreting design comps into layouts.

## Screenshot
![image](https://user-images.githubusercontent.com/1080928/86271769-65daa200-bbc5-11ea-9b62-0239a3e84af1.png)
