### PR TITLE
Use line-height in favour of padding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16399,6 +16399,7 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",

--- a/src/components/Select/index.vue
+++ b/src/components/Select/index.vue
@@ -127,9 +127,7 @@ export default {
   @apply bg-transparent pl-4 pr-10 w-full border border-black rounded-md text-black cursor-pointer;
   -webkit-appearance: none;
   -moz-appearance: none;
-  line-height: 1;
-  padding-bottom: 0.75rem;
-  padding-top: 0.75rem;
+  line-height: 2.5;
   transition: border-color 300ms ease-in-out;
 }
 .select__input:not([disabled]):hover {


### PR DESCRIPTION
## Summary

This PR fixes the select boxes to stop cutoff text. We're using line height to set the height of the select box as opposed to padding.

## Type of Change

- [x] :rocket: New Feature
- [x] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]

## Screenshot/Video

![image](https://user-images.githubusercontent.com/1080928/90144232-76f70100-dd76-11ea-8764-b5488ac824b3.png)
