### PR TITLE
fix(Tab): Keep same height when selected

### DIFF
--- a/src/components/Tab/index.vue
+++ b/src/components/Tab/index.vue
@@ -117,7 +117,6 @@ export default {
 <style scoped>
 .tab {
   @apply border-b-2 border-border flex flex-none items-center outline-none;
-  min-height: 40px;
   min-width: 8rem;
 }
 .tab::before {

--- a/src/components/Typography/index.vue
+++ b/src/components/Typography/index.vue
@@ -189,7 +189,7 @@ export default {
 .typography--variant-label-large {
   font-size: 1rem;
   font-weight: 500;
-  line-height: 1rem;
+  line-height: 1.188rem;
 }
 .typography--variant-label-small {
   font-size: 0.75rem;


### PR DESCRIPTION
By giving the Tab component a min-height of 40 pixels, it always maintains the same height when selected or not selected.

### Before
<img width="1792" alt="Screen Shot 2020-08-18 at 7 55 44 AM" src="https://user-images.githubusercontent.com/3810951/90515645-90a69880-e128-11ea-9120-de6b9650fa6b.png">
<img width="1792" alt="Screen Shot 2020-08-18 at 7 55 48 AM" src="https://user-images.githubusercontent.com/3810951/90515646-913f2f00-e128-11ea-9e0a-f76fa8779d6f.png">

### After
<img width="1792" alt="Screen Shot 2020-08-18 at 7 56 00 AM" src="https://user-images.githubusercontent.com/3810951/90515675-99976a00-e128-11ea-9d00-02032a4be344.png">
<img width="1792" alt="Screen Shot 2020-08-18 at 7 56 05 AM" src="https://user-images.githubusercontent.com/3810951/90515676-9a300080-e128-11ea-9d76-84d795cbcfcc.png">
